### PR TITLE
refactor: improve coap message handling

### DIFF
--- a/pkg/coap/errors.go
+++ b/pkg/coap/errors.go
@@ -1,0 +1,43 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package coap
+
+import (
+	"encoding/json"
+
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+)
+
+type coapProxyError struct {
+	statusCode codes.Code
+	err        error
+}
+
+type COAPProxyError interface {
+	error
+	MarshalJSON() ([]byte, error)
+	StatusCode() codes.Code
+}
+
+var _ COAPProxyError = (*coapProxyError)(nil)
+
+func (cpe *coapProxyError) Error() string {
+	return cpe.err.Error()
+}
+
+func (cpe *coapProxyError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Error string `json:"message"`
+	}{
+		Error: cpe.err.Error(),
+	})
+}
+
+func (cpe *coapProxyError) StatusCode() codes.Code {
+	return cpe.statusCode
+}
+
+func NewCOAPProxyError(statusCode codes.Code, err error) COAPProxyError {
+	return &coapProxyError{statusCode: statusCode, err: err}
+}


### PR DESCRIPTION
Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/magistrala/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?

### Which issue(s) does this PR fix/relate to?
Put here `Resolves #XXX` to auto-close the issue that your PR fixes (if such)

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes

## Summary by Sourcery

Refactor CoAP proxy to improve message handling by adding structured error handling and responses, extracting an authentication query parameter, broadening UDP address support, and refining proxy lifecycle and logging.

New Features:
- Add structured COAPProxyError type with JSON marshaling and send CoAP error responses upstream and over DTLS
- Parse “auth” URI query parameter into session context for CoAP POST/GET authentication
- Switch UDP listener to support both IPv4 and IPv6 by using network "udp" instead of "udp6"

Enhancements:
- Delay starting downstream proxy reader until after first successful upstream write using an atomic flag
- Increase DTLS downstream read deadline from 10s to 30s
- Standardize logging calls with slog.String and harmonize error messages
- Simplify proxy loops by removing redundant selects and clarifying control flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CoAP authentication via URI query (auth=VALUE) for POST and GET flows.
  - Automatic CoAP error responses returned to clients with appropriate status codes.
  - Generic UDP/DTLS addressing support (no longer IPv6-specific).
  - Per-client connection management for more reliable upstream/downstream messaging.

- **Improvements**
  - More resilient UDP handling: log-and-continue on client issues.
  - Start downstream reading after first successful upstream write to reduce overhead.
  - Extended downstream read timeout (30s) for improved stability.
  - Minor logging and style refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->